### PR TITLE
Fix Ansible Compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,8 +26,8 @@
     kernel_modules_conf_dir: "/etc/modprobe.d"
   when: not s.stat.exists
 
-- include: blacklist-modules.yml
+- include_tasks: blacklist-modules.yml
 
-- include: unload-modules.yml
+- include_tasks: unload-modules.yml
 
-- include: load-modules.yml
+- include_tasks: load-modules.yml


### PR DESCRIPTION
The module is no longer compatible with the latest version of Ansible:

```shell
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.

The error appears to be in '/home/thijs/.ansible/roles/galexrt.kernel-modules/tasks/main.yml': line 26, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- include: blacklist-modules.yml
  ^ here
```

I've renamed all uses of `include` to `include_tasks` which fixes the issue.